### PR TITLE
Fixed catboost and added new tqdm

### DIFF
--- a/src/arfs/feature_selection/allrelevant.py
+++ b/src/arfs/feature_selection/allrelevant.py
@@ -494,7 +494,7 @@ class Leshy(SelectorMixin, BaseEstimator):
         n_estimators : int
             the number of trees
         """
-        depth = self.estimator.get_params()["max_depth"]
+        depth = self.estimator.get_params()["max_depth"] if not self.is_cat else self.estimator.get_param("max_depth")
         if depth is None:
             depth = 10
         # how many times a feature should be considered on average

--- a/src/arfs/feature_selection/allrelevant.py
+++ b/src/arfs/feature_selection/allrelevant.py
@@ -56,7 +56,7 @@ import matplotlib.pyplot as plt
 import scipy as sp
 
 from typing import Tuple
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from sklearn.utils import check_random_state, check_X_y
 from sklearn.base import BaseEstimator, is_regressor, is_classifier, clone
 

--- a/src/arfs/feature_selection/mrmr.py
+++ b/src/arfs/feature_selection/mrmr.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_is_fitted
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from sklearn.feature_selection._base import SelectorMixin
 from ..association import (
     f_stat_classification_parallel,

--- a/src/arfs/preprocessing.py
+++ b/src/arfs/preprocessing.py
@@ -11,7 +11,7 @@ This module provides preprocessing classes
 
 # Settings and libraries
 from __future__ import print_function
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 # pandas
 import pandas as pd


### PR DESCRIPTION
Hi, I see you've been working on the project, you are doing great job!

Catboost does not have keys of parameters, which weren't passed in initialization, so your `_get_tree_num` will raise KeyError. My PR fixes it.
```python
from arfs.feature_selection import Leshy
from catboost import CatBoostClassifier
from sklearn.datasets import load_iris


x, y = load_iris(return_X_y=True, as_frame=True)

estimator = CatBoostClassifier()
leshy = Leshy(estimator, n_estimators="auto")
leshy.fit(x, y)
```
gives KeyError

Also when I was using your module in jupyter notebook, it has been using not fancy looking tqdm. It is easy to fix by using
`from tqdm.auto import tqdm` which will import nice tqdm if it can, otherwise will use usual version.