### PR TITLE
Relax dependency on lightgbm

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ package_dir =
 packages=find_namespace:
 python_requires = >=3.9
 install_requires =
-    lightgbm==3.3.1
+    lightgbm>=3.3.1
     matplotlib>=3.5
     numpy>=1.21
     pandas>=1.4
@@ -46,7 +46,7 @@ arfs.dataset.description =
     *.rst
 
 [options.extras_require]
-docs = 
+docs =
     ipykernel
     ipython_genutils
     pandoc
@@ -58,6 +58,6 @@ docs =
     sphinx-tabs==3.4.1
     fasttreeshap
 
-test = 
+test =
     pytest
     pytest-cov


### PR DESCRIPTION
Latest version of `lightgbm` is 4.3, but `arfs` is hard-pinning version 3.3.1. This PR relaxes the dependency to allow for more recent lightgbm versions